### PR TITLE
fix rule 1.7.1.1: scripts in /etc/update-mot.d must be executable

### DIFF
--- a/tasks/level-1/1.7.1.1.yml
+++ b/tasks/level-1/1.7.1.1.yml
@@ -24,7 +24,10 @@
 - name: 1.7.1.1 - Ensure message of the day is configured properly
   copy:
     dest: "/etc/update-motd.d/99-banner"
-    content: "{{ cis_local_login_warning_banner }}"
+    content: |
+      #!/usr/bin/env sh
+      echo "{{ cis_local_login_warning_banner }}"
+    mode: 0700
   tags:
     - level-1
     - 1.7.1.1


### PR DESCRIPTION
and contain shell etc. script code

thanks @RiccardoBoettcher
